### PR TITLE
Fix gpspipe argument incompatibility in constants.py for Rocky Linux 8

### DIFF
--- a/lincot/constants.py
+++ b/lincot/constants.py
@@ -25,4 +25,4 @@ DEFAULT_COT_STALE: str = "3600"  # 1 hour
 DEFAULT_COT_TYPE: str = "a-f-G-E-S"
 
 DEFAULT_POLL_INTERVAL: int = 61
-DEFAULT_GPS_INFO_CMD: str = "gpspipe --json -n 5"
+DEFAULT_GPS_INFO_CMD: str = "gpspipe -w -n 5"


### PR DESCRIPTION
## Fix `gpspipe` Argument Incompatibility in `constants.py` for Rocky Linux 8

### Summary

On Rocky Linux 8 with `gpspipe` version 3.19, the `--json` argument is unsupported. This causes Lincot to fail during execution. This issue was reported in GitHub issue #[Issue_Number].

### Details

The `constants.py` file contained a string `DEFAULT_GPS_INFO_CMD` that was using this incompatible `--json` argument. This commit replaces the `--json` argument with `-w` in the `DEFAULT_GPS_INFO_CMD` string, making the `gpspipe` command compatible across different versions.

### File Changed

- **Modified**: `DEFAULT_GPS_INFO_CMD` in `constants.py`  
  *From*: `gpspipe --json -n 5`  
  *To*: `gpspipe -w -n 5`

### Testing

- Manually tested on Rocky Linux 8 with `gpspipe` version 3.19.
- Confirmed that Lincot now runs without errors.

### Conclusion

This change should make Lincot more robust and compatible across different Linux distributions and `gpspipe` versions.
